### PR TITLE
add device (d-link dwa-182 rev d1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Only STA/Monitor Mode is supported, no AP.
 A few known wireless cards that use this driver include 
 * [Edimax EW-7822ULC](http://us.edimax.com/edimax/merchandise/merchandise_detail/data/edimax/us/wireless_adapters_ac1200_dual-band/ew-7822ulc/)
 * [ASUS AC-53 NANO](https://www.asus.com/Networking/USB-AC53-Nano/)
+* [D-Link DWA-182 (Revision D1 only)](http://ca.dlink.com/products/connect/wireless-ac1200-dual-band-usb-adapter/)
 
 
 > NOTE: At least v4.7 is needed to compile this module

--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -239,6 +239,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE(0x7392, 0xB822), .driver_info = RTL8822B}, /* Edimax - EW-7822ULC */
 	{USB_DEVICE(0x0b05, 0x184c), .driver_info = RTL8822B}, /* ASUS USB AC53 */
 	{USB_DEVICE(0x7392, 0xC822), .driver_info = RTL8822B}, /* Edimax - EW-7822UTC */
+	{USB_DEVICE(0x2001, 0x331c), .driver_info = RTL8822B}, /* D-Link - DWA-182 Rev D */
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0xB82C, 0xff, 0xff, 0xff), .driver_info = RTL8822B}, /* Default ID */
 #endif /* CONFIG_RTL8822B */
 


### PR DESCRIPTION
Hi there,
I have a D-Link DWA182 (revision D1) which uses the same RTL8812BU chip as the Asus AC53 Nano and Edimax EW-7822UTC USB dongles (according to [this list](https://wikidevi.com/wiki/Special:Ask?title=Special%3AAsk&q=[[Chip1+model::RTL8812BU]])).
I added the device ID and it works for me now.