### PR TITLE
Fix compilation in kernel 5.2

### DIFF
--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1297,7 +1297,7 @@ static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
           #else
             , struct net_device *sb_dev
           #endif
-	#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(5, 2, 0))
 	, select_queue_fallback_t fallback
 	#endif
 #endif


### PR DESCRIPTION
This patch fixes compilation caused by API changes in kernel 5.2.
This API change was made on the following commit:
https://github.com/torvalds/linux/commit/a350eccee5830d9a1f29e393a88dc05a15326d44#diff-cf45716f2ff8e67a1727be77c3b894feR1268
