### PR TITLE
Guard reference to wiphy_vendor_command policy attribute

### DIFF
--- a/os_dep/linux/rtw_cfgvendor.c
+++ b/os_dep/linux/rtw_cfgvendor.c
@@ -37,6 +37,9 @@
 
 #include <net/rtnetlink.h>
 
+#define KERNEL_HAS_CFG80211_WIPHY_VENDOR_COMMAND_POLICY \
+    (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 3, 0))
+
 #ifdef DBG_MEM_ALLOC
 extern bool match_mstat_sniff_rules(const enum mstat_f flags, const size_t size);
 struct sk_buff *dbg_rtw_cfg80211_vendor_event_alloc(struct wiphy *wiphy, struct wireless_dev *wdev, int len, int event_id, gfp_t gfp
@@ -1400,7 +1403,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
 		.doit = rtw_cfgvendor_lstats_get_info,
+#if KERNEL_HAS_CFG80211_WIPHY_VENDOR_COMMAND_POLICY
 		.policy = VENDOR_CMD_RAW_DATA,
+#endif /* KERNEL_HAS_CFG80211_WIPHY_VENDOR_COMMAND_POLICY */
 	},
 	{
 		{
@@ -1409,7 +1414,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
 		.doit = rtw_cfgvendor_lstats_set_info,
+#if KERNEL_HAS_CFG80211_WIPHY_VENDOR_COMMAND_POLICY
 		.policy = VENDOR_CMD_RAW_DATA,
+#endif /* KERNEL_HAS_CFG80211_WIPHY_VENDOR_COMMAND_POLICY */
 	},
 	{
 		{
@@ -1418,7 +1425,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
 		.doit = rtw_cfgvendor_lstats_clear_info,
+#if KERNEL_HAS_CFG80211_WIPHY_VENDOR_COMMAND_POLICY
 		.policy = VENDOR_CMD_RAW_DATA,
+#endif /* KERNEL_HAS_CFG80211_WIPHY_VENDOR_COMMAND_POLICY */
 	},
 #endif /* CONFIG_RTW_CFGVEDNOR_LLSTATS */
 	{
@@ -1428,7 +1437,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
 		.doit = rtw_cfgvendor_get_feature_set,
+#if KERNEL_HAS_CFG80211_WIPHY_VENDOR_COMMAND_POLICY
 		.policy = VENDOR_CMD_RAW_DATA,
+#endif /* KERNEL_HAS_CFG80211_WIPHY_VENDOR_COMMAND_POLICY */
 	},
 	{
 		{
@@ -1437,7 +1448,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
 		.doit = rtw_cfgvendor_get_feature_set_matrix,
+#if KERNEL_HAS_CFG80211_WIPHY_VENDOR_COMMAND_POLICY
 		.policy = VENDOR_CMD_RAW_DATA,
+#endif /* KERNEL_HAS_CFG80211_WIPHY_VENDOR_COMMAND_POLICY */
 	}
 };
 


### PR DESCRIPTION
If these guards are not present, the driver will not build against kernel versions which do not have the policy attribute (e.g. Linux Kernel < v5.3).