### PR TITLE
add DKMS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,15 @@ A few known wireless cards that use this driver include
 Currently tested on X86_64 and ARM platform(s) **only**,  
 cross compile possible.
 
-For compiling type  
+For manual installation type  
 `make`  
-in source dir  
-
-To install the firmware files  
+in source dir; then, to install the firmware files  
 `sudo make install`
+
+Or, for DKMS-compatible distros, (after installing `dkms` package,) place or link the source dir as  
+`/usr/src/rtl8822bu-git`  
+then execute  
+`sudo dkms install rtl8822bu/git`
 
 
 To Unload driver you may need to disconnect the device  

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,12 +1,14 @@
 PACKAGE_NAME="rtl8822bu"
-#PACKAGE_VERSION=$(git log -1 --format=%cd --date='format:git-%Y%m%d')
+#PACKAGE_VERSION="git-$(git log -1 --format=%cd --date='format:%Y%m%d')"
 PACKAGE_VERSION="git"
 BUILT_MODULE_NAME="88x2bu"
 PROCS_NUM=$(nproc)
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
-MAKE="'make' -j$PROCS_NUM KVER=${kernelver} 
-KSRC=/lib/modules/${kernelver}/build"
+MAKE="'make'
+ -j$PROCS_NUM
+ KVER=${kernelver}
+ KSRC=/lib/modules/${kernelver}/build"
 CLEAN="'make' clean"
 DEST_MODULE_LOCATION="/kernel/drivers/net/wireless"
 AUTOINSTALL="yes"
-REMAKE_INITRD=no 
+REMAKE_INITRD=no

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,12 @@
+PACKAGE_NAME="rtl8822bu"
+#PACKAGE_VERSION=$(git log -1 --format=%cd --date='format:git-%Y%m%d')
+PACKAGE_VERSION="git"
+BUILT_MODULE_NAME="88x2bu"
+PROCS_NUM=$(nproc)
+[ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
+MAKE="'make' -j$PROCS_NUM KVER=${kernelver} 
+KSRC=/lib/modules/${kernelver}/build"
+CLEAN="'make' clean"
+DEST_MODULE_LOCATION="/kernel/drivers/net/wireless"
+AUTOINSTALL="yes"
+REMAKE_INITRD=no 


### PR DESCRIPTION
It seems this was lacking a DKMS configuration file; I've snatched+modified one off the AUR that looks like it might have been yours in the first place, so presumably it's up to snuff for this repo.

I have validated the change, it looks all ready to go:

![2020-01-03-151934](https://user-images.githubusercontent.com/2776014/71749967-98852700-2e3c-11ea-8957-8a4c41cd48a4.jpg)