### PR TITLE
Fix build with kernel 5.8

### DIFF
--- a/core/rtw_security.c
+++ b/core/rtw_security.c
@@ -2140,6 +2140,7 @@ BIP_exit:
 
 #ifndef PLATFORM_FREEBSD
 /* compress 512-bits */
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0))
 static int sha256_compress(struct sha256_state *md, unsigned char *buf)
 {
 	u32 S[8], W[64], t0, t1;
@@ -2186,8 +2187,10 @@ static int sha256_compress(struct sha256_state *md, unsigned char *buf)
 		md->state[i] = md->state[i] + S[i];
 	return 0;
 }
+#endif
 
 /* Initialize the hash state */
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0))
 static void sha256_init(struct sha256_state *md)
 {
 	md->curlen = 0;
@@ -2201,6 +2204,7 @@ static void sha256_init(struct sha256_state *md)
 	md->state[6] = 0x1F83D9ABUL;
 	md->state[7] = 0x5BE0CD19UL;
 }
+#endif
 
 /**
    Process a block of memory though the hash
@@ -2209,6 +2213,7 @@ static void sha256_init(struct sha256_state *md)
    @param inlen  The length of the data (octets)
    @return CRYPT_OK if successful
 */
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0))
 static int sha256_process(struct sha256_state *md, unsigned char *in,
 			  unsigned long inlen)
 {
@@ -2242,6 +2247,7 @@ static int sha256_process(struct sha256_state *md, unsigned char *in,
 
 	return 0;
 }
+#endif
 
 
 /**
@@ -2250,6 +2256,7 @@ static int sha256_process(struct sha256_state *md, unsigned char *in,
    @param out [out] The destination of the hash (32 bytes)
    @return CRYPT_OK if successful
 */
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0))
 static int sha256_done(struct sha256_state *md, unsigned char *out)
 {
 	int i;
@@ -2288,6 +2295,7 @@ static int sha256_done(struct sha256_state *md, unsigned char *out)
 
 	return 0;
 }
+#endif
 
 /**
  * sha256_vector - SHA256 hash for data vector
@@ -2297,6 +2305,7 @@ static int sha256_done(struct sha256_state *md, unsigned char *out)
  * @mac: Buffer for the hash
  * Returns: 0 on success, -1 of failure
  */
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0))
 static int sha256_vector(size_t num_elem, u8 *addr[], size_t *len,
 			 u8 *mac)
 {
@@ -2311,6 +2320,7 @@ static int sha256_vector(size_t num_elem, u8 *addr[], size_t *len,
 		return -1;
 	return 0;
 }
+#endif
 
 static u8 os_strlen(const char *s)
 {
@@ -2347,6 +2357,7 @@ static int os_memcmp(const void *s1, const void *s2, u8 n)
  * @len: Lengths of the data blocks
  * @mac: Buffer for the hash (32 bytes)
  */
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0))
 static void hmac_sha256_vector(u8 *key, size_t key_len, size_t num_elem,
 			       u8 *addr[], size_t *len, u8 *mac)
 {
@@ -2423,6 +2434,7 @@ static void hmac_sha256_vector(u8 *key, size_t key_len, size_t num_elem,
  * given key.
  */
 #ifndef PLATFORM_FREEBSD /* Baron */
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0))
 static void sha256_prf(u8 *key, size_t key_len, char *label,
 		       u8 *data, size_t data_len, u8 *buf, size_t buf_len)
 {
@@ -2459,6 +2471,7 @@ static void sha256_prf(u8 *key, size_t key_len, char *label,
 		counter++;
 	}
 }
+#endif
 #endif /* PLATFORM_FREEBSD Baron */
 
 /* AES tables*/
@@ -3299,6 +3312,7 @@ int tdls_verify_mic(u8 *kck, u8 trans_seq,
 	return _FAIL;
 
 }
+#endif
 #endif /* CONFIG_TDLS */
 
 /* Restore HW wep key setting according to key_mask */

--- a/include/rtw_security.h
+++ b/include/rtw_security.h
@@ -249,11 +249,13 @@ struct security_priv {
 #define SEC_IS_BIP_KEY_INSTALLED(sec) _FALSE
 #endif
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0))
 struct sha256_state {
 	u64 length;
 	u32 state[8], curlen;
 	u8 buf[64];
 };
+#endif
 
 #define GET_ENCRY_ALGO(psecuritypriv, psta, encry_algo, bmcst)\
 	do {\

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -7030,6 +7030,7 @@ exit:
 	return ret;
 }
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0))
 static void cfg80211_rtw_mgmt_frame_register(struct wiphy *wiphy,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 6, 0))
 	struct wireless_dev *wdev,
@@ -7037,7 +7038,15 @@ static void cfg80211_rtw_mgmt_frame_register(struct wiphy *wiphy,
 	struct net_device *ndev,
 #endif
 	u16 frame_type, bool reg)
+#else
+static void cfg80211_rtw_update_mgmt_frame_register(struct wiphy *wiphy,
+						    struct wireless_dev *wdev,
+						    struct mgmt_frame_regs *upd)
+#endif
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0))
+	u32 rtw_mask = BIT(IEEE80211_STYPE_PROBE_REQ >> 4);
+#endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 6, 0))
 	struct net_device *ndev = wdev_to_ndev(wdev);
 #endif
@@ -7052,13 +7061,19 @@ static void cfg80211_rtw_mgmt_frame_register(struct wiphy *wiphy,
 	pwdev_priv = adapter_wdev_data(adapter);
 
 #ifdef CONFIG_DEBUG_CFG80211
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0))
 	RTW_INFO(FUNC_ADPT_FMT" frame_type:%x, reg:%d\n", FUNC_ADPT_ARG(adapter),
 		frame_type, reg);
+#else
+	RTW_INFO(FUNC_ADPT_FMT " old_regs:%x new_regs:%x\n",
+		 FUNC_ADPT_ARG(adapter), pwdev_priv->mgmt_mask, upd->interface_stypes);
+#endif    
 #endif
 
 	/* Wait QC Verify */
 	return;
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0))
 	switch (frame_type) {
 	case IEEE80211_STYPE_PROBE_REQ: /* 0x0040 */
 		SET_CFG80211_REPORT_MGMT(pwdev_priv, IEEE80211_STYPE_PROBE_REQ, reg);
@@ -7069,7 +7084,12 @@ static void cfg80211_rtw_mgmt_frame_register(struct wiphy *wiphy,
 	default:
 		break;
 	}
+#else
+	if ((upd->interface_stypes & rtw_mask) == (pwdev_priv->mgmt_mask & rtw_mask))
+ 		return;
 
+	pwdev_priv->mgmt_mask = upd->interface_stypes;
+#endif
 exit:
 	return;
 }
@@ -9344,7 +9364,11 @@ static struct cfg80211_ops rtw_cfg80211_ops = {
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE)
 	.mgmt_tx = cfg80211_rtw_mgmt_tx,
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0))	
 	.mgmt_frame_register = cfg80211_rtw_mgmt_frame_register,
+#else
+	.update_mgmt_frame_registrations = cfg80211_rtw_update_mgmt_frame_register,
+#endif
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 34) && LINUX_VERSION_CODE <= KERNEL_VERSION(2, 6, 35))
 	.action = cfg80211_rtw_mgmt_tx,
 #endif

--- a/os_dep/linux/ioctl_cfg80211.h
+++ b/os_dep/linux/ioctl_cfg80211.h
@@ -164,6 +164,9 @@ struct rtw_wdev_priv {
 	bool block;
 	bool block_scan;
 	bool power_mgmt;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)
+	u32 mgmt_mask;
+#endif
 
 	/* report mgmt_frame registered */
 	u16 report_mgmt;


### PR DESCRIPTION
This patch has been retrieved (and slightly updated to remove empty lines, fix indentation) from: https://github.com/aircrack-ng/rtl8188eus/commit/ad543d26166c24fee4aae9940f28dce4dcbd32d3

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>