### PR TITLE
Addition of tp-link Archer T4U  to known devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A few known wireless cards that use this driver include
 * [Edimax EW-7822ULC](http://us.edimax.com/edimax/merchandise/merchandise_detail/data/edimax/us/wireless_adapters_ac1200_dual-band/ew-7822ulc/)
 * [ASUS AC-53 NANO](https://www.asus.com/Networking/USB-AC53-Nano/)
 * [D-Link DWA-182 (Revision D1 only)](http://ca.dlink.com/products/connect/wireless-ac1200-dual-band-usb-adapter/)
+* [tp-link Archer T4U (Revision V3 only)](https://www.tp-link.com/us/home-networking/usb-adapter/archer-t4u/)
+
 
 
 > NOTE: At least v4.7 is needed to compile this module


### PR DESCRIPTION
Addition of tp-link Archer T4U (Revision V3 only)  to known devices
Tested and confirmed on Kali Linux with kernel version 5.8.0-kali2-amd64