### PR TITLE
fix build with gcc < 10 due to fallthrough

### DIFF
--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -1826,10 +1826,7 @@ void mgt_dispatcher(_adapter *padapter, union recv_frame *precv_frame)
 			ptable->func = &OnAuth;
 		else
 			ptable->func = &OnAuthClient;
-
-#if __GNUC__ > 6
-		[[fallthrough]];
-#endif
+		// fallthrough
 
 	case WIFI_ASSOCREQ:
 	case WIFI_REASSOCREQ:

--- a/hal/hal_halmac.c
+++ b/hal/hal_halmac.c
@@ -2695,11 +2695,7 @@ static int _send_general_info(struct dvobj_priv *d)
 	case HALMAC_RET_NO_DLFW:
 		RTW_WARN("%s: halmac_send_general_info() fail because fw not dl!\n",
 			 __FUNCTION__);
-
-#if __GNUC__ > 6
-		[[fallthrough]];
-#endif
-
+		// fallthrough
 	default:
 		return -1;
 	}

--- a/hal/hal_intf.c
+++ b/hal/hal_intf.c
@@ -942,11 +942,7 @@ s32 c2h_handler(_adapter *adapter, u8 id, u8 seq, u8 plen, u8 *payload)
 	case C2H_EXTEND:
 		sub_id = payload[0];
 		/* no handle, goto default */
-
-#if __GNUC__ > 6
-		[[fallthrough]];
-#endif
-
+		// fallthrough
 	default:
 		if (phydm_c2H_content_parsing(adapter_to_phydm(adapter), id, plen, payload) != TRUE)
 			ret = _FAIL;

--- a/hal/halmac/halmac_88xx/halmac_mimo_88xx.c
+++ b/hal/halmac/halmac_88xx/halmac_mimo_88xx.c
@@ -62,16 +62,10 @@ cfg_txbf_88xx(struct halmac_adapter *adapter, u8 userid, enum halmac_bw bw,
 		switch (bw) {
 		case HALMAC_BW_80:
 			tmp42c |= BIT_R_TXBF0_80M;
-
-  #if __GNUC__ > 6
-			[[fallthrough]];
-  #endif 
+			// fallthrough
 		case HALMAC_BW_40:
 			tmp42c |= BIT_R_TXBF0_40M;
-    #if __GNUC__ > 6
-			 [[fallthrough]];
-    #endif
-
+			// fallthrough
 		case HALMAC_BW_20:
 			tmp42c |= BIT_R_TXBF0_20M;
 			break;

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -2366,8 +2366,8 @@ static int cfg80211_rtw_change_iface(struct wiphy *wiphy,
 	#if defined(CONFIG_P2P) && ((LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE))
 	case NL80211_IFTYPE_P2P_CLIENT:
 		is_p2p = _TRUE;
-		// fallthrough
 	#endif
+		// fallthrough
 	case NL80211_IFTYPE_STATION:
 		networkType = Ndis802_11Infrastructure;
 
@@ -2391,8 +2391,8 @@ static int cfg80211_rtw_change_iface(struct wiphy *wiphy,
 	#if defined(CONFIG_P2P) && ((LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE))
 	case NL80211_IFTYPE_P2P_GO:
 		is_p2p = _TRUE;
-		// fallthrough
 	#endif
+		// fallthrough
 	case NL80211_IFTYPE_AP:
 		networkType = Ndis802_11APMode;
 

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -2366,11 +2366,7 @@ static int cfg80211_rtw_change_iface(struct wiphy *wiphy,
 	#if defined(CONFIG_P2P) && ((LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE))
 	case NL80211_IFTYPE_P2P_CLIENT:
 		is_p2p = _TRUE;
-
-#if __GNUC__ > 6
-		[[fallthrough]];
-#endif
-
+		// fallthrough
 	#endif
 	case NL80211_IFTYPE_STATION:
 		networkType = Ndis802_11Infrastructure;
@@ -2395,11 +2391,7 @@ static int cfg80211_rtw_change_iface(struct wiphy *wiphy,
 	#if defined(CONFIG_P2P) && ((LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE))
 	case NL80211_IFTYPE_P2P_GO:
 		is_p2p = _TRUE;
-
-#if __GNUC__ > 6
-		[[fallthrough]];
-#endif
-
+		// fallthrough
 	#endif
 	case NL80211_IFTYPE_AP:
 		networkType = Ndis802_11APMode;


### PR DESCRIPTION
[[fallthrough]] is a C++17 statement so it can't be used in plain C code
and will raise a build failure with at least gcc 8

The standard and portable way could be to use
__attribute__ ((fallthrough)); but it does not seem to be really
supported (e.g https://github.com/antoineco/broadcom-wl/pull/12)

So just use a magical comment that should be understood by gcc > 7 and
ignored by older compilers, this is ugly but it works

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>