### PR TITLE
Fix scan timestamps + minor cleanup

### DIFF
--- a/core/rtw_mlme.c
+++ b/core/rtw_mlme.c
@@ -1082,6 +1082,16 @@ bool rtw_update_scanned_network(_adapter *adapter, WLAN_BSSID_EX *target)
 
 		update_network(&(pnetwork->network), target, adapter, update_ie);
 	}
+	/*
+	 * report network only if the current channel set contains the channel
+	 * to which this network belongs. Report early so that we have a valid
+	 * scan timestamp, finish up in scan-done callback.
+	 */
+	if (rtw_chset_search_ch(adapter_to_chset(adapter),
+				pnetwork->network.Configuration.DSConfig) >= 0
+	    && rtw_mlme_band_check(adapter, pnetwork->network.Configuration.DSConfig) == _TRUE
+	    && _TRUE == rtw_validate_ssid(&(pnetwork->network.Ssid)))
+		rtw_cfg80211_inform_bss(adapter, pnetwork);
 
 unlock_scan_queue:
 	_exit_critical_bh(&queue->lock, &irqL);

--- a/core/rtw_mlme.c
+++ b/core/rtw_mlme.c
@@ -1107,7 +1107,6 @@ unlock_scan_queue:
 	return update_ie;
 }
 
-void rtw_add_network(_adapter *adapter, WLAN_BSSID_EX *pnetwork);
 void rtw_add_network(_adapter *adapter, WLAN_BSSID_EX *pnetwork)
 {
 	_irqL irqL;
@@ -1142,7 +1141,6 @@ void rtw_add_network(_adapter *adapter, WLAN_BSSID_EX *pnetwork)
  *			   (3) WMM
  *			   (4) HT
  * (5) others */
-int rtw_is_desired_network(_adapter *adapter, struct wlan_network *pnetwork);
 int rtw_is_desired_network(_adapter *adapter, struct wlan_network *pnetwork)
 {
 	struct security_priv *psecuritypriv = &adapter->securitypriv;

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -2600,15 +2600,10 @@ static void _rtw_cfg80211_surveydone_event_callback(_adapter *padapter, struct c
 
 		pnetwork = LIST_CONTAINOR(plist, struct wlan_network, list);
 
-		/* report network only if the current channel set contains the channel to which this network belongs */
 		if (rtw_chset_search_ch(adapter_to_chset(padapter), pnetwork->network.Configuration.DSConfig) >= 0
-			&& rtw_mlme_band_check(padapter, pnetwork->network.Configuration.DSConfig) == _TRUE
-			&& _TRUE == rtw_validate_ssid(&(pnetwork->network.Ssid))
-		) {
-			if (target_wps_scan)
-				rtw_cfg80211_clear_wps_sr_of_non_target_bss(padapter, pnetwork, &target_ssid);
-			rtw_cfg80211_inform_bss(padapter, pnetwork);
-		}
+		    && rtw_mlme_band_check(padapter, pnetwork->network.Configuration.DSConfig) == _TRUE
+		    && _TRUE == rtw_validate_ssid(&(pnetwork->network.Ssid)) && target_wps_scan)
+			rtw_cfg80211_clear_wps_sr_of_non_target_bss(padapter, pnetwork, &target_ssid);
 #if 0
 		/* check ralink testbed RSN IE length */
 		{


### PR DESCRIPTION
The result of `iw <dev> scan dump` command returns wrong timestamps associated with observed APs and I have traced it to a driver issue. This PR is a quick fix, tested on several Realtek cards that I got my hands on and it's simple enough that it fixes the issue and doesn't break anything. There is probably room for more optimization later, but this will fix the acute problem.